### PR TITLE
remove ubuntu18 build, no longer supported by Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,10 +23,6 @@ strategy:
       imageName: 'ubuntu-20.04'
       the_name: 'Azure Pipelines'
 
-    ubuntu_18_04_gcc_8:
-      imageName: 'ubuntu-18.04'
-      the_name: 'Azure Pipelines'
-
     mac_12:
       imageName: 'macos-12'
       the_name: 'Azure Pipelines'


### PR DESCRIPTION
ubuntu18 is no longer supported :
https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml